### PR TITLE
Update to Vagrant 2.1.x, use built-in vagrant snapshot command

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -34,7 +34,7 @@ To get started, ensure you have the following installed:
  1. Run `vagrant up` to prepare the machine for testing.
    * **Note** due to the way that vagrant works, the first time that you run this command, the vagrant box named __ferventcoder/win2012r2-x64-nocm__ needs to be downloaded from the [Atlas website](https://atlas.hashicorp.com/ferventcoder/boxes/win2012r2-x64-nocm).  This will take quite a while, and should only be attempted on a reasonably fast connection, that doesn't have any download limit restrictions. Once it has downloaded it will import the box and apply the scripts and configurations to the box as listed inside the `Vagrantfile`.  You can find the downloaded box in the `~/.vagrant.d` or `c:\users\username\.vagrant.d` folder.
  1. Now the box is ready for you to start testing against.
- 1. Run the following command: `vagrant snapshot create good`.  This takes a snapshot of the VM using the built-in snapshot functionality. This means that after testing packages, the VM can be returned to this known "good" state.
+ 1. Run the following command: `vagrant snapshot save good`.  This takes a snapshot of the VM using the built-in snapshot functionality. This means that after testing packages, the VM can be returned to this known "good" state.
 
 ### Testing a Package
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -18,9 +18,8 @@ You need a computer with:
 ## Setup
 
 To get started, ensure you have the following installed:
- * Vagrant 1.8.1+ - linked clones is the huge reason here. You can technically use any version of Vagrant 1.3.5+. But you will get the best performance with 1.8.x.
- * Virtualbox 4.3.28+ (5.x may have issues, so try to stay in 4.3.x series)
- * vagrant sahara plugin (`vagrant plugin install sahara`)
+ * Vagrant 2.1+ - linked clones is the huge reason here. You can technically use any version of Vagrant 1.3.5+. But you will get the best performance with 2.1.x.
+ * VirtualBox 5.2+
 
 ## Running Verification Manually
 
@@ -35,7 +34,7 @@ To get started, ensure you have the following installed:
  1. Run `vagrant up` to prepare the machine for testing.
    * **Note** due to the way that vagrant works, the first time that you run this command, the vagrant box named __ferventcoder/win2012r2-x64-nocm__ needs to be downloaded from the [Atlas website](https://atlas.hashicorp.com/ferventcoder/boxes/win2012r2-x64-nocm).  This will take quite a while, and should only be attempted on a reasonably fast connection, that doesn't have any download limit restrictions. Once it has downloaded it will import the box and apply the scripts and configurations to the box as listed inside the `Vagrantfile`.  You can find the downloaded box in the `~/.vagrant.d` or `c:\users\username\.vagrant.d` folder.
  1. Now the box is ready for you to start testing against.
- 1. Run the following command: `vagrant sandbox on`.  This takes a snapshot of the VM using the [vagrant plugin](https://github.com/jedi4ever/sahara) that was installed earlier. This means that after testing packages, the VM can be returned to this known "good" state.
+ 1. Run the following command: `vagrant snapshot create good`.  This takes a snapshot of the VM using the built-in snapshot functionality. This means that after testing packages, the VM can be returned to this known "good" state.
 
 ### Testing a Package
 
@@ -48,11 +47,11 @@ For testing a package, you have two avenues. For a locally built package, you ca
 
 ### Make Changes and Retest
 
-When you need to investigate making changes and rerunning the tests, remember that we took a snapshot of the vagrant machine (the virtual machine), so we can rollback to the earlier state each time and move forward with testing changes without the possibility of lingering artifacts. This is why we are using the sahara vagrant plugin, it allows us to take a snapshot and then revert the virtual machine back to the previous state.
+When you need to investigate making changes and rerunning the tests, remember that we took a snapshot of the vagrant machine (the virtual machine), so we can rollback to the earlier state each time and move forward with testing changes without the possibility of lingering artifacts. This is why we are using the `vagrant snapshot` command, it allows us to take a snapshot and then revert the virtual machine back to the previous state.
 
 When you are ready to reset to the state just before installing:
 
- 1. Run `vagrant sandbox rollback`
+ 1. Run `vagrant snapshot restore good --no-provision`
  1. Follow the steps in testing a package (previous section).
 
 ### Tearing Down the Testing Environment


### PR DESCRIPTION
I used the choco test environment with Vagrant 2.1.2 and VirtualBox 5.2.x on my Mac. So I skipped the sahara plugin and just used the built-in `vagrant snapshot` command.

Here are the steps I did instead.

The `vagrant snapshot restore` still runs the provision script by default (which my be useful here). This will change in the future that no provision script is called automatically.
