### PR TITLE
(GH-33) Resolve HyperV deprecation warning for differencing vs linked clone

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,7 +50,11 @@ Vagrant.configure("2") do |config|
     # The time in seconds to wait for the virtual machine to report an IP address
     v.ip_address_timeout = 130
     # Use differencing disk instead of cloning whole VHD
-    v.differencing_disk = true
+    if Vagrant::VERSION >= '2.1.2'
+      v.linked_clone = true
+    else
+      v.differencing_disk = true
+    end
     v.vm_integration_services = {
       guest_service_interface: true,
       heartbeat: true,


### PR DESCRIPTION
Reference:
https://github.com/hashicorp/vagrant/blob/v2.1.2/website/source/docs/hyperv/configuration.html.md

Technically speaking, even

```ruby
v.differencing_disk = true
```

requires 1.8.3, but I think nobody is using that old Vagrant anyway.

Closes #33