### PR TITLE
(GH-56) Update to work with new Vagrant box

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -31,7 +31,7 @@ You need a computer with:
 
 To get started, ensure you have the following installed:
  * Vagrant 1.8.1+ - linked clones is the huge reason here. You can technically use any version of Vagrant 1.3.5+. But you will get the best performance with 1.8.x+. It appears you can go up to Vagrant 2.1.5, but may have some issues with 2.2.2 and Windows guests (newer versions may be fine).
- * Virtualbox 4.3.28+ - 5.2.20 (this flows in the selection of Vagrant - 5.2.22 seems to have some issues but newer versions may work fine)
+ * Virtualbox 4.3.28+ - 6.1.6 (this flows in the selection of Vagrant - 5.2.22 seems to have some issues but newer versions may work fine) 
  * vagrant sahara plugin (`vagrant plugin install sahara`)
 
 **NOTE:** If you decide to run with version 1.8.1 of Vagrant, you are going to need to set the `VAGRANT_SERVER_URL` environment variable as described in this [forum post](https://groups.google.com/forum/#!msg/vagrant-up/H8C68UTkosU/qz4YUmAgBAAJ), otherwise, you will get an HTTP 404 error when attempting to download the base vagrant box used here.
@@ -47,7 +47,7 @@ To get started, ensure you have the following installed:
  1. Open a command line (`PowerShell.exe`/`cmd.exe` on Windows, `bash` everywhere else) and navigate to the root folder of the repository.  You know you are in the right place when you do a `dir` or `ls` and `Vagrantfile` is in your path.
    * No idea if bash on Windows (through Git/CygWin) is supported. If you run into issues, it is better to just use `PowerShell.exe` or `cmd.exe`. Please do not file issues stating it doesn't work.
  1. Run `vagrant up` to prepare the machine for testing.
-   * **Note** due to the way that vagrant works, the first time that you run this command, the vagrant box named __ferventcoder/win2012r2-x64-nocm__ needs to be downloaded from the [Atlas website](https://atlas.hashicorp.com/ferventcoder/boxes/win2012r2-x64-nocm).  This will take quite a while, and should only be attempted on a reasonably fast connection, that doesn't have any download limit restrictions. Once it has downloaded it will import the box and apply the scripts and configurations to the box as listed inside the `Vagrantfile`.  You can find the downloaded box in the `~/.vagrant.d` or `c:\users\username\.vagrant.d` folder.
+   * **Note** due to the way that vagrant works, the first time that you run this command, the vagrant box named __chocolatey/test-environment__ needs to be downloaded from the [Vagrant Cloud](https://app.vagrantup.com/chocolatey/boxes/test-environment).  This will take quite a while, and should only be attempted on a reasonably fast connection, that doesn't have any download limit restrictions. Once it has downloaded it will import the box and apply the scripts and configurations to the box as listed inside the `Vagrantfile`.  You can find the downloaded box in the `~/.vagrant.d` or `c:\users\username\.vagrant.d` folder.
  1. Now the box is ready for you to start testing against.
  1. Run the following command: `vagrant sandbox on`.  This takes a snapshot of the VM using the [vagrant plugin](https://github.com/jedi4ever/sahara) that was installed earlier. This means that after testing packages, the VM can be returned to this known "good" state.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ end
 Vagrant.configure("2") do |config|
   # This setting will download the atlas box at
   # https://atlas.hashicorp.com/ferventcoder/boxes/win2012r2-x64-nocm
-  config.vm.box = "ferventcoder/win2012r2-x64-nocm"
+  config.vm.box = "chocolatey/test-environment"
 
   # http://docs.vagrantup.com/v2/providers/configuration.html
   # http://docs.vagrantup.com/v2/virtualbox/configuration.html
@@ -111,11 +111,13 @@ Vagrant.configure("2") do |config|
     config.vm.provision :shell, :path => "shell/InstallNet4.ps1"
     config.vm.provision :shell, :path => "shell/InstallChocolatey.ps1"
     config.vm.provision :shell, :path => "shell/NotifyGuiAppsOfEnvironmentChanges.ps1"
+    config.vm.provision :shell, :path => "shell/PostSetup.ps1"
   else
     config.vm.provision :shell, :path => "shell/PrepareWindows.ps1", :powershell_elevated_interactive => true
     config.vm.provision :shell, :path => "shell/InstallNet4.ps1", :powershell_elevated_interactive => true
     config.vm.provision :shell, :path => "shell/InstallChocolatey.ps1", :powershell_elevated_interactive => true
     config.vm.provision :shell, :path => "shell/NotifyGuiAppsOfEnvironmentChanges.ps1", :powershell_elevated_interactive => true
+    config.vm.provision :shell, :path => "shell/PostSetup.ps1", :powershell_elevated_interactive => true
   end
 
 $packageTestScript = <<SCRIPT

--- a/shell/ChocolateyAction.ps1
+++ b/shell/ChocolateyAction.ps1
@@ -1,7 +1,21 @@
-$ErrorActionPreference = "Stop"
-$env:PATH +=";$($env:SystemDrive)\ProgramData\chocolatey\bin"
+$env:PATH += ";$($env:SystemDrive)\ProgramData\chocolatey\bin"
 # https://github.com/chocolatey/choco/issues/512
 $validExitCodes = @(0, 1605, 1614, 1641, 3010)
+
+# Attempt to set highest encryption available for SecurityProtocol.
+# PowerShell will not set this by default (until maybe .NET 4.6.x). This
+# will typically produce a message for PowerShell v2 (just an info
+# message though)
+try {
+  # Set TLS 1.2 (3072) as that is the minimum required by Chocolatey.org.
+  # Use integers because the enumeration value for TLS 1.2 won't exist
+  # in .NET 4.0, even though they are addressable if .NET 4.5+ is
+  # installed (.NET 4.5 is an in-place upgrade).
+  [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+}
+catch {
+  Write-Output 'Unable to set PowerShell to use TLS 1.2. This is required for contacting Chocolatey as of 03 FEB 2020. https://chocolatey.org/blog/remove-support-for-old-tls-versions. If you see underlying connection closed or trust errors, you may need to do one or more of the following: (1) upgrade to .NET Framework 4.5+ and PowerShell v3+, (2) Call [System.Net.ServicePointManager]::SecurityProtocol = 3072; in PowerShell prior to attempting installation, (3) specify internal Chocolatey package location (set $env:chocolateyDownloadUrl prior to install or host the package internally), (4) use the Download + PowerShell method of install. See https://chocolatey.org/docs/installation for all install options.'
+}
 
 [[Command]]
 

--- a/shell/InstallChocolatey.ps1
+++ b/shell/InstallChocolatey.ps1
@@ -92,3 +92,4 @@ if (!(Test-Path $ChocoInstallPath)) {
 choco feature enable -n autouninstaller
 choco feature enable -n allowGlobalConfirmation
 choco feature enable -n logEnvironmentValues
+choco feature disable -n showDownloadProgress

--- a/shell/PostSetup.ps1
+++ b/shell/PostSetup.ps1
@@ -1,0 +1,6 @@
+# These KB's are installed on the Vagrant box. 'Register' them with Chocolatey by installing them as noop
+choco install kb2919442 --version 1.0.20160915 --skip-powershell -y -v
+choco install kb2919355 --version 1.0.20160915 --skip-powershell -y -v
+choco install kb2999226 --version 1.0.20181019 --skip-powershell -y -v
+choco install kb3035131 --version 1.0.3 --skip-powershell -y -v
+choco install kb3118401 --version 1.0.5 --skip-powershell -y -v

--- a/shell/PrepareWindows.ps1
+++ b/shell/PrepareWindows.ps1
@@ -1,16 +1,27 @@
+# this is necessary for packages that use one-click deploy
 # Adapted from http://stackoverflow.com/a/29571064/18475
-$AdminKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}"
-$UserKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}"
-New-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0 -Force | Out-Null
-New-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0 -Force | Out-Null
-Stop-Process -Name Explorer -Force
-Write-Output "IE Enhanced Security Configuration (ESC) has been disabled."
 
-# http://techrena.net/disable-ie-set-up-first-run-welcome-screen/
-New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 1 -PropertyType "DWord" -Force | Out-Null
-Write-Output "IE first run welcome screen has been disabled."
+try {
+    $AdminKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A7-37EF-4b3f-8CFC-4F3A74704073}"
+    $UserKey = "HKLM:\SOFTWARE\Microsoft\Active Setup\Installed Components\{A509B1A8-37EF-4b3f-8CFC-4F3A74704073}"
+    New-ItemProperty -Path $AdminKey -Name "IsInstalled" -Value 0 -Force | Out-Null
+    New-ItemProperty -Path $UserKey -Name "IsInstalled" -Value 0 -Force | Out-Null
+    Stop-Process -Name Explorer -Force
+    Write-Output 'IE Enhanced Security Configuration (ESC) has been disabled. Required for One-Click deploy to work appropriately.'
+}
+catch {
+    Write-Output 'Unable to disable IE ESC. Packages that use one click deploy will be so disappointed.'
+}
+
+try {
+    # this is necessary for packages that use one-click deploy
+    # http://techrena.net/disable-ie-set-up-first-run-welcome-screen/
+    New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Internet Explorer\Main" -Name "DisableFirstRunCustomize" -Value 1 -PropertyType "DWord" -Force | Out-Null
+    Write-Output 'IE first run welcome screen has been disabled. Required for One-Click deploy to work appropriately.'
+}
+catch {
+    Write-Output 'Unable to disable IE First Run Welcome Screen. Packages that use one click deploy will be so disappointed.'
+}
 
 Write-Output 'Setting Windows Update service to Manual startup type.'
 Set-Service -Name wuauserv -StartupType Manual
-
-#Set-ExecutionPolicy Unrestricted


### PR DESCRIPTION
Update is to allow working with the new Vagrant chocolatey/test-environment box. This new box has updates already installed so Chocolatey needs to noop the installation of these to ensure they are registered as Chocolatey packages.