### PR TITLE
Replace dead verifier link in readme

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 # Chocolatey Testing Environment
 
-A testing environment setup similar to the [package-verifier](https://github.com/chocolatey/package-verifier/wiki) for testing packages. Over time this will add more Windows platforms for testing.
+A testing environment setup similar to the [package-verifier](https://docs.chocolatey.org/en-us/community-repository/moderation/package-verifier) for testing packages. Over time this will add more Windows platforms for testing.
 
 When creating packages or testing other parts of Chocolatey, this environment provides a good base for an independent testing minus any dependencies you may already have installed. It also allows you to completely destroy an environment and then just tear it down without worry about messing up something on your own system.
 


### PR DESCRIPTION
Update the url to the verifier docs.  Current one is 404